### PR TITLE
Enable Calibration menu on the H2D

### DIFF
--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -3491,9 +3491,8 @@ void MainFrame::update_calibration_button_status()
 {
     Preset &printer_preset = wxGetApp().preset_bundle->printers.get_edited_preset();
     bool isBBL = printer_preset.is_bbl_vendor_preset(wxGetApp().preset_bundle);
-    bool is_multi_extruder = wxGetApp().preset_bundle->get_printer_extruder_count() > 1;
     // Show calibration Menu for BBL printers if Develop Mode is on.
-    bool show_calibration = (!isBBL || wxGetApp().app_config->get("developer_mode") == "true") && !is_multi_extruder;
+    bool show_calibration = (!isBBL || wxGetApp().app_config->get("developer_mode") == "true")
     wxGetApp().mainframe->show_calibration_button(show_calibration);
 }
 


### PR DESCRIPTION
I'm happy you've integrated [my previous contribution](ttps://github.com/bambulab/BambuStudio/pull/6765) to allow Bambu Lab customers to more finely manual tune their filaments on most of your line of printers. That's a win for the user experience, in my opinion.

<img width="1406" height="453" alt="Screenshot 2025-07-17 at 09 26 44" src="https://github.com/user-attachments/assets/fba2b9e2-05b2-4c17-a779-81000190927b" />


But the _entire point_ of https://github.com/bambulab/BambuStudio/pull/6765 was to enable the calibration menu for H2D printers, since Bambu's choices made it impossible to finely tune filament with other slicers.

The choice to exclude the H2D feels user-hostile, without some sort of technical reason why you'd make the user experience more confusing. It's weird and confusing that I can see the menu in Bambu Studio when connected to my X1C, but it disappears when I choose my H2D.

Yes, there are many workaround to get the calibrations to run on my H2D. 

_**None of them should be necessary**_. 