### PR TITLE
Wrap text in the Configuration Update changelog display

### DIFF
--- a/src/slic3r/GUI/UpdateDialogs.cpp
+++ b/src/slic3r/GUI/UpdateDialogs.cpp
@@ -187,7 +187,10 @@ MsgUpdateConfig::MsgUpdateConfig(const std::vector<Update> &updates, bool force_
 
     auto *versions = new wxBoxSizer(wxVERTICAL);
     // BBS: use changelog string instead of url
-    wxStaticText *changelog_textctrl = new wxStaticText(m_scrollwindw_release_note, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(FromDIP(560), -1));
+    const int changelog_width = FromDIP(560);
+    wxStaticText *changelog_textctrl = new wxStaticText(m_scrollwindw_release_note, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(changelog_width, -1));
+    changelog_textctrl->SetMinSize(wxSize(changelog_width, -1));
+    changelog_textctrl->SetMaxSize(wxSize(changelog_width, -1));
 
 
     for (const auto &update : updates) {
@@ -225,6 +228,8 @@ MsgUpdateConfig::MsgUpdateConfig(const std::vector<Update> &updates, bool force_
 
     ////BBS: use changelog string instead of url
     if (changelog_textctrl) 
+        changelog_textctrl->Wrap(changelog_width);
+    if (changelog_textctrl)
 		content_sizer->Add(changelog_textctrl, 1, wxEXPAND | wxTOP, FromDIP(30));
 
 


### PR DESCRIPTION
Hard to view a changelog when it doesn't wordwrap or have a horizontal scrollbar.

This adds wordwrap.

Before:

<img width="1624" height="963" alt="Screenshot 2025-12-08 at 22 35 14" src="https://github.com/user-attachments/assets/a0ff7275-8cc1-43b9-ab00-45d32aa0817d" />

After:
<img width="1912" height="963" alt="Screenshot 2025-12-09 at 01 08 21" src="https://github.com/user-attachments/assets/b81c2360-ceb5-4055-bfcf-45598fe73e69" />
