### PR TITLE
Fix per-extruder nozzle matching and compatibility checks

### DIFF
--- a/src/libslic3r/GCode/ToolOrdering.cpp
+++ b/src/libslic3r/GCode/ToolOrdering.cpp
@@ -1510,11 +1510,13 @@ void ToolOrdering::reorder_extruders_for_minimum_flush_volume(bool reorder_first
             for (auto& item : maps_without_group)
                 item = 0;
 
+            const size_t fallback_extruder_id = used_filaments.empty() ? 0 : used_filaments.front();
+
             MultiNozzleUtils::NozzleInfo tmp;
-            tmp.diameter = print_config->nozzle_diameter.get_at(0);
+            tmp.diameter = print_config->nozzle_diameter.get_at(fallback_extruder_id);
             tmp.group_id = 0;
-            tmp.extruder_id = 0;
-            tmp.volume_type = NozzleVolumeType::nvtStandard;
+            tmp.extruder_id = fallback_extruder_id;
+            tmp.volume_type = static_cast<NozzleVolumeType>(print_config->nozzle_volume_type.get_at(fallback_extruder_id));
 
             MultiNozzleUtils::MultiNozzleGroupResult result(maps_without_group, { tmp }, used_filaments);
 

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -1654,8 +1654,15 @@ bool PartPlate::check_mixture_filament_compatible(const DynamicPrintConfig &conf
 
 bool PartPlate::check_compatible_of_nozzle_and_filament(const DynamicPrintConfig &config, const std::vector<std::string> &filament_presets, std::string &error_msg)
 {
-    float nozzle_diameter = config.option<ConfigOptionFloatsNullable>("nozzle_diameter")->values[0];
+    const auto *nozzle_diameter_opt = config.option<ConfigOptionFloatsNullable>("nozzle_diameter");
+    if (nozzle_diameter_opt == nullptr || nozzle_diameter_opt->values.empty())
+        return true;
+
     auto  volume_type_opt = config.option<ConfigOptionEnumsGeneric>("nozzle_volume_type");
+    if (volume_type_opt == nullptr || volume_type_opt->values.empty())
+        return true;
+
+    std::vector<int> used_filaments = get_extruders(true); // 1 based
 
     auto get_filament_alias = [](std::string preset_name) -> std::string {
         size_t      at_pos = preset_name.find('@');
@@ -1666,20 +1673,8 @@ bool PartPlate::check_compatible_of_nozzle_and_filament(const DynamicPrintConfig
         return alias.substr(first, last - first + 1);
     };
 
-    bool with_same_volume_type = std::all_of(volume_type_opt->values.begin(), volume_type_opt->values.end(),
-                                             [first_value = volume_type_opt->values[0]](int value) { return value == first_value; });
-
     std::set<std::string> selected_filament_alias;
     for (auto &filament_preset : filament_presets) { selected_filament_alias.insert(get_filament_alias(filament_preset)); }
-
-    auto get_incompatible_selected = [&](const NozzleVolumeType volume_type) -> std::set<std::string> {
-        std::vector<std::string> incompatible_filaments = Print::get_incompatible_filaments_by_nozzle(nozzle_diameter, volume_type);
-        std::set<std::string>    ret;
-        for (auto &filament : selected_filament_alias) {
-            if (std::find(incompatible_filaments.begin(), incompatible_filaments.end(), filament) != incompatible_filaments.end()) ret.insert(filament);
-        }
-        return ret;
-    };
 
     auto get_nozzle_msg = [](const float nozzle_diameter, const NozzleVolumeType volume_type) -> std::string {
         std::ostringstream oss;
@@ -1702,29 +1697,38 @@ bool PartPlate::check_compatible_of_nozzle_and_filament(const DynamicPrintConfig
 
     error_msg.clear();
 
-    std::set<int>                                     nozzle_volumes(volume_type_opt->values.begin(), volume_type_opt->values.end());
-    std::map<NozzleVolumeType, std::set<std::string>> incompatible_selected_map;
+    std::map<std::string, std::set<std::string>> incompatible_selected_map;
 
-    for (auto volume_type_value : nozzle_volumes) {
-        NozzleVolumeType volume_type           = static_cast<NozzleVolumeType>(volume_type_value);
-        auto             incompatible_selected = get_incompatible_selected(volume_type);
-        if (!incompatible_selected.empty()) incompatible_selected_map[volume_type] = incompatible_selected;
+    for (int filament_id : used_filaments) {
+        const int extruder_id = filament_id - 1;
+        if (extruder_id < 0 || extruder_id >= int(nozzle_diameter_opt->values.size()) || extruder_id >= int(volume_type_opt->values.size()))
+            continue;
+
+        const float            extruder_nozzle_diameter = nozzle_diameter_opt->values[extruder_id];
+        const NozzleVolumeType volume_type              = static_cast<NozzleVolumeType>(volume_type_opt->values[extruder_id]);
+        std::vector<std::string> incompatible_filaments = Print::get_incompatible_filaments_by_nozzle(extruder_nozzle_diameter, volume_type);
+
+        const std::string key = get_nozzle_msg(extruder_nozzle_diameter, volume_type);
+        for (const auto &filament : selected_filament_alias) {
+            if (std::find(incompatible_filaments.begin(), incompatible_filaments.end(), filament) != incompatible_filaments.end())
+                incompatible_selected_map[key].insert(filament);
+        }
     }
 
     if (incompatible_selected_map.empty()) return true;
 
     if (incompatible_selected_map.size() == 1) {
-        auto             elem                  = incompatible_selected_map.begin();
-        NozzleVolumeType volume_type           = elem->first;
-        auto             incompatible_selected = elem->second;
-        error_msg = GUI::format(_L("It is not recommended to print the following filament(s) with %1%: %2%\n"), get_nozzle_msg(nozzle_diameter, volume_type),
+        auto        elem                  = incompatible_selected_map.begin();
+        std::string nozzle_msg            = elem->first;
+        auto        incompatible_selected = elem->second;
+        error_msg = GUI::format(_L("It is not recommended to print the following filament(s) with %1%: %2%\n"), nozzle_msg,
                                 get_incompatible_filament_msg(incompatible_selected));
     } else {
         std::string warning_msg = _u8L("It is not recommended to use the following nozzle and filament combinations:\n");
         for (auto &elem : incompatible_selected_map) {
-            NozzleVolumeType volume_type           = elem.first;
-            auto             incompatible_selected = elem.second;
-            warning_msg += GUI::format(_L("%1% with %2%\n"),get_nozzle_msg(nozzle_diameter, volume_type), get_incompatible_filament_msg(incompatible_selected));
+            auto nozzle_msg            = elem.first;
+            auto incompatible_selected = elem.second;
+            warning_msg += GUI::format(_L("%1% with %2%\n"), nozzle_msg, get_incompatible_filament_msg(incompatible_selected));
         }
         error_msg = warning_msg;
     }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -17407,8 +17407,7 @@ Preset *get_printer_preset(const MachineObject *obj)
     if (!obj)
         return nullptr;
 
-    Preset       *printer_preset = nullptr;
-    float machine_nozzle_diameter = obj->GetExtderSystem()->GetNozzleDiameter(0);
+    Preset *printer_preset = nullptr;
     PresetBundle *preset_bundle  = wxGetApp().preset_bundle;
     for (auto printer_it = preset_bundle->printers.begin(); printer_it != preset_bundle->printers.end(); printer_it++) {
         // only use system printer preset
@@ -17421,8 +17420,24 @@ Preset *get_printer_preset(const MachineObject *obj)
         std::string model_id = printer_it->get_current_printer_type(preset_bundle);
 
         std::string printer_type = obj->get_show_printer_type();
-        if (model_id.compare(printer_type) == 0 && printer_nozzle_vals && abs(printer_nozzle_vals->get_at(0) - machine_nozzle_diameter) < 1e-3) {
+        if (model_id.compare(printer_type) != 0 || !printer_nozzle_vals)
+            continue;
+
+        const size_t machine_extruder_count = obj->GetExtderSystem()->GetTotalExtderCount();
+        if (printer_nozzle_vals->values.size() != machine_extruder_count)
+            continue;
+
+        bool matched_nozzle_vector = true;
+        for (size_t i = 0; i < printer_nozzle_vals->values.size(); ++i) {
+            if (std::abs(printer_nozzle_vals->get_at(i) - obj->GetExtderSystem()->GetNozzleDiameter(i)) >= 1e-3f) {
+                matched_nozzle_vector = false;
+                break;
+            }
+        }
+
+        if (matched_nozzle_vector) {
             printer_preset = &(*printer_it);
+            break;
         }
     }
     return printer_preset;

--- a/src/slic3r/GUI/SyncAmsInfoDialog.cpp
+++ b/src/slic3r/GUI/SyncAmsInfoDialog.cpp
@@ -1884,8 +1884,7 @@ bool SyncAmsInfoDialog::is_same_nozzle_diameters(NozzleType &tag_nozzle_type, fl
 {
     bool is_same_nozzle_diameters = true;
 
-    float       preset_nozzle_diameters;
-    std::string preset_nozzle_type;
+    float preset_nozzle_diameters = 0.f;
 
     DeviceManager *dev = Slic3r::GUI::wxGetApp().getDeviceManager();
     if (!dev) return true;
@@ -1914,16 +1913,18 @@ bool SyncAmsInfoDialog::is_same_nozzle_diameters(NozzleType &tag_nozzle_type, fl
         }
         std::sort(used_extruders.begin(), used_extruders.end());
 
-        // TODO [tao wang] : add idx mapping
-        tag_nozzle_type = obj_->GetExtderSystem()->GetNozzleType(0);
-
         if (opt_nozzle_diameters != nullptr) {
-            for (auto i = 0; i < used_extruders.size(); i++) {
+            for (size_t i = 0; i < used_extruders.size(); i++) {
                 auto extruder           = used_extruders[i];
                 preset_nozzle_diameters = float(opt_nozzle_diameters->get_at(extruder));
-                if (preset_nozzle_diameters != obj_->GetExtderSystem()->GetNozzleDiameter(0)) { is_same_nozzle_diameters = false; }
+                if (std::abs(preset_nozzle_diameters - obj_->GetExtderSystem()->GetNozzleDiameter(extruder)) >= 1e-3f) {
+                    is_same_nozzle_diameters = false;
+                }
             }
         }
+
+        const int tag_extruder = used_extruders.empty() ? 0 : used_extruders.front();
+        tag_nozzle_type        = obj_->GetExtderSystem()->GetNozzleType(tag_extruder);
 
     } catch (...) {}
 


### PR DESCRIPTION
### Motivation
- Eliminate lingering assumptions that only extruder 0 defines nozzle diameter and volume type so mixed-nozzle (per-extruder) presets and validations behave correctly.
- Ensure UI/device matching and filament-compatibility messaging reflect the full per-extruder nozzle vector instead of synthesizing a single nozzle from index 0.
- Use a safer fallback in tool-ordering/statistics code by selecting a real used extruder when computing single-extruder stats.

### Description
- Update printer preset matching in `Plater::get_printer_preset()` to require the preset nozzle vector to match the machine's full per-extruder nozzle vector and to verify extruder counts match (`src/slic3r/GUI/Plater.cpp`).
- Fix AMS sync validation in `SyncAmsInfoDialog::is_same_nozzle_diameters()` to compare each used extruder's preset nozzle diameter against the corresponding machine nozzle and to derive the tag nozzle type from the first used extruder (`src/slic3r/GUI/SyncAmsInfoDialog.cpp`).
- Rework nozzle/filament compatibility warnings to evaluate incompatible filaments per used extruder (per-extruder diameter + volume type) and aggregate messages by nozzle description (`src/slic3r/GUI/PartPlate.cpp`).
- Remove a hardcoded extruder-0 assumption in the tool-ordering fallback path by selecting a fallback extruder from `used_filaments` and using its diameter/volume type for `NozzleInfo` (`src/libslic3r/GCode/ToolOrdering.cpp`).

### Testing
- Ran `git diff --check` to ensure no whitespace/diff errors and the check passed.
- Committed the changes and verified the working tree shows the four updated files (`Plater.cpp`, `SyncAmsInfoDialog.cpp`, `PartPlate.cpp`, `ToolOrdering.cpp`).
- No build or unit-test runs were performed in this change set; further integration/build verification is recommended before release.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4f9b894808324a235b6b13c51a6af)