### PR TITLE
Add first-pass mixed-nozzle grid validation and nozzle-vector matching

### DIFF
--- a/src/libslic3r/GCode/ToolOrdering.cpp
+++ b/src/libslic3r/GCode/ToolOrdering.cpp
@@ -1510,8 +1510,20 @@ void ToolOrdering::reorder_extruders_for_minimum_flush_volume(bool reorder_first
             for (auto& item : maps_without_group)
                 item = 0;
 
+            double single_extruder_diameter = 0.;
+            for (unsigned int filament_id : used_filaments) {
+                if (filament_id >= filament_maps.size())
+                    continue;
+                const int extruder_idx = filament_maps[filament_id];
+                if (extruder_idx < 0)
+                    continue;
+                single_extruder_diameter = std::max(single_extruder_diameter, print_config->nozzle_diameter.get_at(extruder_idx));
+            }
+            if (single_extruder_diameter <= 0. && !print_config->nozzle_diameter.values.empty())
+                single_extruder_diameter = print_config->nozzle_diameter.values.front();
+
             MultiNozzleUtils::NozzleInfo tmp;
-            tmp.diameter = print_config->nozzle_diameter.get_at(0);
+            tmp.diameter = format_diameter_to_str(single_extruder_diameter);
             tmp.group_id = 0;
             tmp.extruder_id = 0;
             tmp.volume_type = NozzleVolumeType::nvtStandard;

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1276,6 +1276,31 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
         return profile;
     };
 
+    std::vector<Slicing::LayerGridObjectSpec> layer_grid_specs;
+    layer_grid_specs.reserve(m_objects.size());
+    for (const PrintObject *object : m_objects) {
+        Slicing::LayerGridObjectSpec spec;
+        const SlicingParameters &slicing_params = object->slicing_parameters();
+        spec.first_print_layer_height = slicing_params.first_print_layer_height;
+        spec.layer_height             = slicing_params.layer_height;
+        spec.min_layer_height         = slicing_params.min_layer_height;
+        spec.max_layer_height         = slicing_params.max_layer_height;
+
+        std::vector<unsigned int> object_extruders = object->object_extruders();
+        spec.uses_multiple_extruders               = object_extruders.size() > 1;
+        spec.nozzle_diameters.reserve(object_extruders.size());
+        for (unsigned int extruder_id : object_extruders)
+            spec.nozzle_diameters.emplace_back(m_config.nozzle_diameter.get_at(extruder_id));
+        layer_grid_specs.emplace_back(std::move(spec));
+    }
+    std::string layer_grid_reason;
+    const Slicing::LayerGridMode layer_grid_mode = Slicing::classify_layer_grid_mode(layer_grid_specs, &layer_grid_reason);
+    if (layer_grid_mode == Slicing::LayerGridMode::Unsupported) {
+        if (!layer_grid_reason.empty())
+            return { layer_grid_reason };
+        return { L("The selected mixed nozzle and layer-grid combination is not supported yet.") };
+    }
+
 
     // Custom layering is not allowed for tree supports as of now.
     for (size_t print_object_idx = 0; print_object_idx < m_objects.size(); ++print_object_idx) {
@@ -1294,17 +1319,12 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
     }
 
     if (this->has_wipe_tower() && ! m_objects.empty()) {
-        // Make sure all extruders use same diameter filament and have the same nozzle diameter
-        // EPSILON comparison is used for nozzles and 10 % tolerance is used for filaments
-        double first_nozzle_diam = m_config.nozzle_diameter.get_at(extruders.front());
+        // Make sure all extruders use same filament diameter (10 % tolerance).
         double first_filament_diam = m_config.filament_diameter.get_at(extruders.front());
         for (const auto& extruder_idx : extruders) {
-            double nozzle_diam = m_config.nozzle_diameter.get_at(extruder_idx);
             double filament_diam = m_config.filament_diameter.get_at(extruder_idx);
-            if (nozzle_diam - EPSILON > first_nozzle_diam || nozzle_diam + EPSILON < first_nozzle_diam
-                || std::abs((filament_diam - first_filament_diam) / first_filament_diam) > 0.1)
-                // BBS: remove L()
-                return { L("Different nozzle diameters and different filament diameters is not allowed when prime tower is enabled.") };
+            if (std::abs((filament_diam - first_filament_diam) / first_filament_diam) > 0.1)
+                return { L("Different filament diameters is not allowed when prime tower is enabled.") };
         }
 
         if (! m_config.use_relative_e_distances)
@@ -1339,21 +1359,29 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
         }
 #endif
 
-        if (m_objects.size() > 1) {
-            // Some of the objects has variable layer height applied by painting or by a table.
-            bool has_custom_layering = std::any_of(m_objects.begin(), m_objects.end(),
-                [](const PrintObject* object) { return object->model_object()->has_custom_layering(); });
+        const bool has_custom_layering = std::any_of(m_objects.begin(), m_objects.end(),
+            [](const PrintObject* object) { return object->model_object()->has_custom_layering(); });
+        if (has_custom_layering && layer_grid_mode != Slicing::LayerGridMode::SharedGrid)
+            return { L("The prime tower with variable layer height requires all objects to use one shared layer grid.") };
 
+        if (m_objects.size() > 1) {
             const SlicingParameters &slicing_params0 = m_objects.front()->slicing_parameters();
-            size_t            tallest_object_idx = 0;
             for (size_t i = 1; i < m_objects.size(); ++ i) {
-                const PrintObject       *object         = m_objects[i];
-                const SlicingParameters &slicing_params = object->slicing_parameters();
-                if (std::abs(slicing_params.first_print_layer_height - slicing_params0.first_print_layer_height) > EPSILON ||
-                    std::abs(slicing_params.layer_height             - slicing_params0.layer_height            ) > EPSILON)
-                    return {L("The prime tower requires that all objects have the same layer heights"), object, "initial_layer_print_height"};
+                const SlicingParameters &slicing_params = m_objects[i]->slicing_parameters();
                 if (slicing_params.raft_layers() != slicing_params0.raft_layers())
-                    return {L("The prime tower requires that all objects are printed over the same number of raft layers"), object, "raft_layers"};
+                    return {L("The prime tower requires that all objects are printed over the same number of raft layers"), m_objects[i], "raft_layers"};
+            }
+
+            if (layer_grid_mode == Slicing::LayerGridMode::SharedGrid) {
+                // Some of the objects has variable layer height applied by painting or by a table.
+                size_t tallest_object_idx = 0;
+
+                for (size_t i = 1; i < m_objects.size(); ++ i) {
+                    const PrintObject       *object         = m_objects[i];
+                    const SlicingParameters &slicing_params = object->slicing_parameters();
+                    if (std::abs(slicing_params.first_print_layer_height - slicing_params0.first_print_layer_height) > EPSILON ||
+                        std::abs(slicing_params.layer_height             - slicing_params0.layer_height            ) > EPSILON)
+                        return {L("The prime tower requires that all objects have the same layer heights"), object, "initial_layer_print_height"};
                 // BBS: support gap can be multiple of object layer height, remove _L()
 #if 0
                 if (slicing_params0.gap_object_support != slicing_params.gap_object_support ||
@@ -1362,39 +1390,40 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
 #endif
                 if (!equal_layering(slicing_params, slicing_params0))
                     return  { L("The prime tower requires that all objects are sliced with the same layer heights."), object };
+                    if (has_custom_layering) {
+                        auto &lh         = layer_height_profile(i);
+                        auto &lh_tallest = layer_height_profile(tallest_object_idx);
+                        if (*(lh.end()-2) > *(lh_tallest.end()-2))
+                            tallest_object_idx = i;
+                    }
+                }
+
+                // BBS: remove obsolete logics and _L()
                 if (has_custom_layering) {
-                    auto &lh         = layer_height_profile(i);
-                    auto &lh_tallest = layer_height_profile(tallest_object_idx);
-                    if (*(lh.end()-2) > *(lh_tallest.end()-2))
-                        tallest_object_idx = i;
-                }
-            }
+                    std::vector<std::vector<coordf_t>> layer_z_series;
+                    layer_z_series.assign(m_objects.size(), std::vector<coordf_t>());
 
-            // BBS: remove obsolete logics and _L()
-            if (has_custom_layering) {
-                std::vector<std::vector<coordf_t>> layer_z_series;
-                layer_z_series.assign(m_objects.size(), std::vector<coordf_t>());
+                    for (size_t idx_object = 0; idx_object < m_objects.size(); ++idx_object) {
+                        layer_z_series[idx_object] = generate_object_layers(m_objects[idx_object]->slicing_parameters(), layer_height_profiles[idx_object], m_objects[idx_object]->config().precise_z_height.value);
+                    }
 
-                for (size_t idx_object = 0; idx_object < m_objects.size(); ++idx_object) {
-                    layer_z_series[idx_object] = generate_object_layers(m_objects[idx_object]->slicing_parameters(), layer_height_profiles[idx_object], m_objects[idx_object]->config().precise_z_height.value);
-                }
-
-                for (size_t idx_object = 0; idx_object < m_objects.size(); ++idx_object) {
-                    if (idx_object == tallest_object_idx) continue;
-                    // Check that the layer height profiles are equal. This will happen when one object is
-                    // a copy of another, or when a layer height modifier is used the same way on both objects.
-                    // The latter case might create a floating point inaccuracy mismatch, so compare
-                    // element-wise using an epsilon check.
-                    size_t         i   = 0;
-                    const coordf_t eps = 0.5 * EPSILON; // layers closer than EPSILON will be merged later. Let's make
-                    // this check a bit more sensitive to make sure we never consider two different layers as one.
-                    while (i < layer_z_series[idx_object].size() && i < layer_z_series[tallest_object_idx].size()) {
-                        // BBS: remove the break condition, because a variable layer height object and a new object will not be checked when slicing
-                        //if (i % 2 == 0 && layer_height_profiles[tallest_object_idx][i] > layer_height_profiles[idx_object][layer_height_profiles[idx_object].size() - 2])
-                        //    break;
-                        if (std::abs(layer_z_series[idx_object][i] - layer_z_series[tallest_object_idx][i]) > eps)
-                            return {L("The prime tower is only supported if all objects have the same variable layer height")};
-                        ++i;
+                    for (size_t idx_object = 0; idx_object < m_objects.size(); ++idx_object) {
+                        if (idx_object == tallest_object_idx) continue;
+                        // Check that the layer height profiles are equal. This will happen when one object is
+                        // a copy of another, or when a layer height modifier is used the same way on both objects.
+                        // The latter case might create a floating point inaccuracy mismatch, so compare
+                        // element-wise using an epsilon check.
+                        size_t         i   = 0;
+                        const coordf_t eps = 0.5 * EPSILON; // layers closer than EPSILON will be merged later. Let's make
+                        // this check a bit more sensitive to make sure we never consider two different layers as one.
+                        while (i < layer_z_series[idx_object].size() && i < layer_z_series[tallest_object_idx].size()) {
+                            // BBS: remove the break condition, because a variable layer height object and a new object will not be checked when slicing
+                            //if (i % 2 == 0 && layer_height_profiles[tallest_object_idx][i] > layer_height_profiles[idx_object][layer_height_profiles[idx_object].size() - 2])
+                            //    break;
+                            if (std::abs(layer_z_series[idx_object][i] - layer_z_series[tallest_object_idx][i]) > eps)
+                                return {L("The prime tower is only supported if all objects have the same variable layer height")};
+                            ++i;
+                        }
                     }
                 }
             }

--- a/src/libslic3r/Slicing.cpp
+++ b/src/libslic3r/Slicing.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+#include <cmath>
 #include <limits>
 
 #include "libslic3r.h"
@@ -59,6 +61,93 @@ coordf_t Slicing::max_layer_height_from_nozzle(const DynamicPrintConfig &print_c
     return std::max(min_layer_height, (max_layer_height == 0.) ? (0.75 * nozzle_dmr) : max_layer_height);
 }
 
+const char *Slicing::layer_grid_mode_name(LayerGridMode mode)
+{
+    switch (mode) {
+    case LayerGridMode::SharedGrid:                    return "shared-grid";
+    case LayerGridMode::SeparateObjectIndependentGrid: return "separate-object-independent-grid";
+    case LayerGridMode::SameObjectCompatibleCadence:   return "same-object-compatible-cadence";
+    case LayerGridMode::Unsupported:                   return "unsupported";
+    }
+    return "unsupported";
+}
+
+bool Slicing::nozzle_vector_has_compatible_cadence(const std::vector<coordf_t> &nozzle_diameters, coordf_t layer_height)
+{
+    if (layer_height <= EPSILON)
+        return false;
+
+    std::vector<coordf_t> sorted = nozzle_diameters;
+    sorted.erase(std::remove_if(sorted.begin(), sorted.end(), [](coordf_t d) { return d <= EPSILON; }), sorted.end());
+    if (sorted.empty())
+        return true;
+
+    std::sort(sorted.begin(), sorted.end());
+    sorted.erase(std::unique(sorted.begin(), sorted.end(), [](coordf_t a, coordf_t b) { return std::abs(a - b) <= EPSILON; }), sorted.end());
+    if (sorted.size() <= 1)
+        return true;
+
+    auto is_integral_ratio = [](double value) {
+        const double rounded = std::round(value);
+        return std::abs(value - rounded) <= 1e-3;
+    };
+
+    const coordf_t base_nozzle = sorted.front();
+    for (coordf_t diameter : sorted) {
+        if (!is_integral_ratio(diameter / layer_height))
+            return false;
+        if (!is_integral_ratio(diameter / base_nozzle))
+            return false;
+    }
+    return true;
+}
+
+Slicing::LayerGridMode Slicing::classify_layer_grid_mode(const std::vector<LayerGridObjectSpec> &objects, std::string *reason)
+{
+    if (reason)
+        reason->clear();
+
+    if (objects.empty())
+        return LayerGridMode::SharedGrid;
+
+    const LayerGridObjectSpec &reference = objects.front();
+    bool shared_grid                     = true;
+    bool same_object_mixed_nozzle        = false;
+
+    for (const LayerGridObjectSpec &object : objects) {
+        if (std::abs(object.first_print_layer_height - reference.first_print_layer_height) > EPSILON ||
+            std::abs(object.layer_height - reference.layer_height) > EPSILON)
+            shared_grid = false;
+
+        if (object.layer_height + EPSILON < object.min_layer_height || object.layer_height > object.max_layer_height + EPSILON) {
+            if (reason)
+                *reason = "The configured layer height is outside nozzle-supported limits.";
+            return LayerGridMode::Unsupported;
+        }
+
+        if (!object.uses_multiple_extruders)
+            continue;
+
+        std::vector<coordf_t> nozzles = object.nozzle_diameters;
+        nozzles.erase(std::remove_if(nozzles.begin(), nozzles.end(), [](coordf_t d) { return d <= EPSILON; }), nozzles.end());
+        std::sort(nozzles.begin(), nozzles.end());
+        nozzles.erase(std::unique(nozzles.begin(), nozzles.end(), [](coordf_t a, coordf_t b) { return std::abs(a - b) <= EPSILON; }), nozzles.end());
+        if (nozzles.size() <= 1)
+            continue;
+
+        same_object_mixed_nozzle = true;
+        if (!nozzle_vector_has_compatible_cadence(nozzles, object.layer_height)) {
+            if (reason)
+                *reason = "Same-object mixed nozzles require an integer-compatible layer cadence.";
+            return LayerGridMode::Unsupported;
+        }
+    }
+
+    if (same_object_mixed_nozzle)
+        return LayerGridMode::SameObjectCompatibleCadence;
+    return shared_grid ? LayerGridMode::SharedGrid : LayerGridMode::SeparateObjectIndependentGrid;
+}
+
 SlicingParameters SlicingParameters::create_from_config(
 	const PrintConfig 		&print_config, 
 	const PrintObjectConfig &object_config,
@@ -99,12 +188,12 @@ SlicingParameters SlicingParameters::create_from_config(
         params.max_suport_layer_height = params.max_layer_height;
     }
     if (object_extruders.empty()) {
-        params.min_layer_height = std::max(params.min_layer_height, min_layer_height_from_nozzle(print_config, 0));
-        params.max_layer_height = std::min(params.max_layer_height, max_layer_height_from_nozzle(print_config, 0));
+        params.min_layer_height = std::max(params.min_layer_height, min_layer_height_from_nozzle(print_config, 1));
+        params.max_layer_height = std::min(params.max_layer_height, max_layer_height_from_nozzle(print_config, 1));
     } else {
         for (unsigned int extruder_id : object_extruders) {
-            params.min_layer_height = std::max(params.min_layer_height, min_layer_height_from_nozzle(print_config, extruder_id));
-            params.max_layer_height = std::min(params.max_layer_height, max_layer_height_from_nozzle(print_config, extruder_id));
+            params.min_layer_height = std::max(params.min_layer_height, min_layer_height_from_nozzle(print_config, int(extruder_id) + 1));
+            params.max_layer_height = std::min(params.max_layer_height, max_layer_height_from_nozzle(print_config, int(extruder_id) + 1));
         }
     }
     params.min_layer_height = std::min(params.min_layer_height, params.layer_height);

--- a/src/libslic3r/Slicing.hpp
+++ b/src/libslic3r/Slicing.hpp
@@ -4,8 +4,10 @@
 #define slic3r_Slicing_hpp_
 
 #include <cstring>
+#include <cstdint>
 #include <map>
 #include <set>
+#include <string>
 #include <type_traits>
 #include <vector>
 
@@ -196,6 +198,30 @@ namespace Slicing {
 	// it should not be smaller than the minimum layer height.
 	// Nozzle index is 1 based.
 	coordf_t max_layer_height_from_nozzle(const DynamicPrintConfig &print_config, int idx_nozzle);
+
+    enum class LayerGridMode : uint8_t {
+        SharedGrid,
+        SeparateObjectIndependentGrid,
+        SameObjectCompatibleCadence,
+        Unsupported
+    };
+
+    struct LayerGridObjectSpec {
+        coordf_t             first_print_layer_height { 0 };
+        coordf_t             layer_height             { 0 };
+        coordf_t             min_layer_height         { 0 };
+        coordf_t             max_layer_height         { 0 };
+        bool                 uses_multiple_extruders  { false };
+        std::vector<coordf_t> nozzle_diameters;
+    };
+
+    // True if the nozzle vector can legally share one object layer cadence.
+    bool nozzle_vector_has_compatible_cadence(const std::vector<coordf_t> &nozzle_diameters, coordf_t layer_height);
+
+    // Classify the print grid mode from per-object specifications.
+    LayerGridMode classify_layer_grid_mode(const std::vector<LayerGridObjectSpec> &objects, std::string *reason = nullptr);
+
+    const char *layer_grid_mode_name(LayerGridMode mode);
 } // namespace Slicing
 
 } // namespace Slic3r

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -1654,8 +1654,29 @@ bool PartPlate::check_mixture_filament_compatible(const DynamicPrintConfig &conf
 
 bool PartPlate::check_compatible_of_nozzle_and_filament(const DynamicPrintConfig &config, const std::vector<std::string> &filament_presets, std::string &error_msg)
 {
-    float nozzle_diameter = config.option<ConfigOptionFloatsNullable>("nozzle_diameter")->values[0];
-    auto  volume_type_opt = config.option<ConfigOptionEnumsGeneric>("nozzle_volume_type");
+    const auto *nozzle_diameter_opt = config.option<ConfigOptionFloatsNullable>("nozzle_diameter");
+    const auto *volume_type_opt     = config.option<ConfigOptionEnumsGeneric>("nozzle_volume_type");
+    if (nozzle_diameter_opt == nullptr || volume_type_opt == nullptr)
+        return true;
+
+    std::set<int>  used_extruders;
+    std::vector<int> used_filaments = get_extruders(true); // 1 based
+    const std::vector<int> filament_maps = get_real_filament_maps(config);
+    for (int filament_id : used_filaments) {
+        if (filament_id <= 0 || filament_id > static_cast<int>(filament_maps.size()))
+            continue;
+        const int logical_extruder = filament_maps[filament_id - 1] - 1;
+        if (logical_extruder < 0)
+            continue;
+        int physical_extruder = get_physical_extruder_by_logical_extruder(config, logical_extruder);
+        if (physical_extruder < 0)
+            physical_extruder = logical_extruder;
+        used_extruders.insert(physical_extruder);
+    }
+    if (used_extruders.empty()) {
+        for (size_t extruder_idx = 0; extruder_idx < nozzle_diameter_opt->values.size(); ++extruder_idx)
+            used_extruders.insert(static_cast<int>(extruder_idx));
+    }
 
     auto get_filament_alias = [](std::string preset_name) -> std::string {
         size_t      at_pos = preset_name.find('@');
@@ -1666,13 +1687,10 @@ bool PartPlate::check_compatible_of_nozzle_and_filament(const DynamicPrintConfig
         return alias.substr(first, last - first + 1);
     };
 
-    bool with_same_volume_type = std::all_of(volume_type_opt->values.begin(), volume_type_opt->values.end(),
-                                             [first_value = volume_type_opt->values[0]](int value) { return value == first_value; });
-
     std::set<std::string> selected_filament_alias;
     for (auto &filament_preset : filament_presets) { selected_filament_alias.insert(get_filament_alias(filament_preset)); }
 
-    auto get_incompatible_selected = [&](const NozzleVolumeType volume_type) -> std::set<std::string> {
+    auto get_incompatible_selected = [&](const float nozzle_diameter, const NozzleVolumeType volume_type) -> std::set<std::string> {
         std::vector<std::string> incompatible_filaments = Print::get_incompatible_filaments_by_nozzle(nozzle_diameter, volume_type);
         std::set<std::string>    ret;
         for (auto &filament : selected_filament_alias) {
@@ -1702,29 +1720,32 @@ bool PartPlate::check_compatible_of_nozzle_and_filament(const DynamicPrintConfig
 
     error_msg.clear();
 
-    std::set<int>                                     nozzle_volumes(volume_type_opt->values.begin(), volume_type_opt->values.end());
-    std::map<NozzleVolumeType, std::set<std::string>> incompatible_selected_map;
+    std::map<std::string, std::set<std::string>> incompatible_selected_map;
+    for (int extruder_idx : used_extruders) {
+        if (extruder_idx < 0 || extruder_idx >= static_cast<int>(nozzle_diameter_opt->values.size()) ||
+            extruder_idx >= static_cast<int>(volume_type_opt->values.size()))
+            continue;
 
-    for (auto volume_type_value : nozzle_volumes) {
-        NozzleVolumeType volume_type           = static_cast<NozzleVolumeType>(volume_type_value);
-        auto             incompatible_selected = get_incompatible_selected(volume_type);
-        if (!incompatible_selected.empty()) incompatible_selected_map[volume_type] = incompatible_selected;
+        const float nozzle_diameter = static_cast<float>(nozzle_diameter_opt->get_at(extruder_idx));
+        NozzleVolumeType volume_type = static_cast<NozzleVolumeType>(volume_type_opt->values[extruder_idx]);
+        auto incompatible_selected = get_incompatible_selected(nozzle_diameter, volume_type);
+        if (incompatible_selected.empty())
+            continue;
+        auto nozzle_msg = get_nozzle_msg(nozzle_diameter, volume_type);
+        auto &merged = incompatible_selected_map[nozzle_msg];
+        merged.insert(incompatible_selected.begin(), incompatible_selected.end());
     }
 
     if (incompatible_selected_map.empty()) return true;
 
     if (incompatible_selected_map.size() == 1) {
-        auto             elem                  = incompatible_selected_map.begin();
-        NozzleVolumeType volume_type           = elem->first;
-        auto             incompatible_selected = elem->second;
-        error_msg = GUI::format(_L("It is not recommended to print the following filament(s) with %1%: %2%\n"), get_nozzle_msg(nozzle_diameter, volume_type),
-                                get_incompatible_filament_msg(incompatible_selected));
+        const auto &elem = *incompatible_selected_map.begin();
+        error_msg = GUI::format(_L("It is not recommended to print the following filament(s) with %1%: %2%\n"), elem.first,
+                                get_incompatible_filament_msg(elem.second));
     } else {
         std::string warning_msg = _u8L("It is not recommended to use the following nozzle and filament combinations:\n");
         for (auto &elem : incompatible_selected_map) {
-            NozzleVolumeType volume_type           = elem.first;
-            auto             incompatible_selected = elem.second;
-            warning_msg += GUI::format(_L("%1% with %2%\n"),get_nozzle_msg(nozzle_diameter, volume_type), get_incompatible_filament_msg(incompatible_selected));
+            warning_msg += GUI::format(_L("%1% with %2%\n"), elem.first, get_incompatible_filament_msg(elem.second));
         }
         error_msg = warning_msg;
     }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -245,6 +245,36 @@ static string get_diameter_string(float diameter)
     return stream.str();
 }
 
+static std::vector<float> get_machine_nozzle_diameter_vector(const MachineObject *obj)
+{
+    std::vector<float> diameters;
+    if (!obj || obj->GetExtderSystem() == nullptr)
+        return diameters;
+
+    const int total_extders = obj->GetExtderSystem()->GetTotalExtderCount();
+    if (total_extders <= 0)
+        return diameters;
+
+    diameters.reserve(static_cast<size_t>(total_extders));
+    for (int idx = 0; idx < total_extders; ++idx)
+        diameters.emplace_back(obj->GetExtderSystem()->GetNozzleDiameter(idx));
+    return diameters;
+}
+
+static bool is_same_nozzle_diameter_vector(const ConfigOptionFloatsNullable *preset_nozzles, const std::vector<float> &machine_nozzles)
+{
+    if (preset_nozzles == nullptr)
+        return machine_nozzles.empty();
+    if (preset_nozzles->values.size() != machine_nozzles.size())
+        return false;
+
+    for (size_t idx = 0; idx < machine_nozzles.size(); ++idx) {
+        if (!is_approx(static_cast<float>(preset_nozzles->get_at(idx)), machine_nozzles[idx]))
+            return false;
+    }
+    return true;
+}
+
 template <typename T, typename OptionType>
 static void set_config_values(DynamicPrintConfig *config, const std::string &key, T value)
 {
@@ -9328,15 +9358,8 @@ void Plater::priv::on_select_preset(wxCommandEvent &evt)
                     PresetBundle *preset_bundle = wxGetApp().preset_bundle;
                     Preset& cur_preset = preset_bundle->printers.get_edited_preset();
                     if (cur_preset.get_printer_type(preset_bundle) == obj->get_show_printer_type()) {
-                        double preset_nozzle_diameter = cur_preset.config.option<ConfigOptionFloatsNullable>("nozzle_diameter")->values[0];
-                        bool   same_nozzle_diameter   = true;
-
-                        const auto& extruders = obj->GetExtderSystem()->GetExtruders();
-                        for (const DevExtder &extruder : extruders) {
-                            if (!is_approx(extruder.GetNozzleDiameter(), float(preset_nozzle_diameter))) {
-                                same_nozzle_diameter = false;
-                            }
-                        }
+                        const auto *preset_nozzles    = cur_preset.config.option<ConfigOptionFloatsNullable>("nozzle_diameter");
+                        bool        same_nozzle_diameter = is_same_nozzle_diameter_vector(preset_nozzles, get_machine_nozzle_diameter_vector(obj));
 
                         if (cur_preset.is_system || (!cur_preset.is_system && same_nozzle_diameter)) {
                             GUI::wxGetApp().sidebar().sync_extruder_list();
@@ -14542,11 +14565,8 @@ bool Plater::try_sync_preset_with_connected_printer(int& nozzle_diameter)
     }
     PresetBundle* preset_bundle = wxGetApp().preset_bundle;
     Preset& printer_preset = preset_bundle->printers.get_selected_preset();
-    double              preset_nozzle_diameter = 0.4;
-    if (auto opt = printer_preset.config.option("nozzle_diameter"); opt) {
-        preset_nozzle_diameter = static_cast<const ConfigOptionFloatsNullable*>(opt)->values[0];
-    }
-    float machine_nozzle_diameter = obj->GetExtderSystem()->GetNozzleDiameter(0);
+    const auto *preset_nozzle_diameters = printer_preset.config.option<ConfigOptionFloatsNullable>("nozzle_diameter");
+    const auto  machine_nozzle_diameters = get_machine_nozzle_diameter_vector(obj);
 
     std::string printer_type = obj->get_show_printer_type();
 
@@ -14562,11 +14582,12 @@ bool Plater::try_sync_preset_with_connected_printer(int& nozzle_diameter)
     nozzle_diameter          = machine_preset->config.option<ConfigOptionFloatsNullable>("nozzle_diameter")->values.size();
     bool is_multi_extruder   = nozzle_diameter > 1;
     if (!wxGetApp().app_config->has("sync_after_load_file_show_flag")) {
-        if (printer_preset.get_current_printer_type(preset_bundle) != printer_type || !is_approx((float)(preset_nozzle_diameter), machine_nozzle_diameter)) {
+        if (printer_preset.get_current_printer_type(preset_bundle) != printer_type ||
+            !is_same_nozzle_diameter_vector(preset_nozzle_diameters, machine_nozzle_diameters)) {
             wxString tips;
             if (printer_preset.get_current_printer_type(preset_bundle) != printer_type)
                 tips = from_u8((boost::format(_u8L("The currently connected printer '%s', is a %s model.\nTo use this printer for printing, please switch the printer model of project file to %s.")) % obj->get_dev_name() % printer_model % printer_model).str());
-            else if (!is_approx((float) (preset_nozzle_diameter), machine_nozzle_diameter))
+            else
                 tips = from_u8((boost::format(_u8L("The currently connected printer '%s', is a %s model but not consistent with preset in project file.\n"
                     "To use this printer for printing, please switch the preset first.")) % obj->get_dev_name() % printer_model).str());
 
@@ -14584,7 +14605,8 @@ bool Plater::try_sync_preset_with_connected_printer(int& nozzle_diameter)
     }
     else {
         sync_printer_preset = wxGetApp().app_config->get("sync_after_load_file_show_flag") == "true";
-        if (sync_printer_preset && printer_preset.get_current_printer_type(preset_bundle) == printer_type && is_approx((float) (preset_nozzle_diameter), machine_nozzle_diameter))
+        if (sync_printer_preset && printer_preset.get_current_printer_type(preset_bundle) == printer_type &&
+            is_same_nozzle_diameter_vector(preset_nozzle_diameters, machine_nozzle_diameters))
             sync_printer_preset = false;
     }
     if (!sync_printer_preset)
@@ -17408,7 +17430,7 @@ Preset *get_printer_preset(const MachineObject *obj)
         return nullptr;
 
     Preset       *printer_preset = nullptr;
-    float machine_nozzle_diameter = obj->GetExtderSystem()->GetNozzleDiameter(0);
+    const auto machine_nozzle_diameters = get_machine_nozzle_diameter_vector(obj);
     PresetBundle *preset_bundle  = wxGetApp().preset_bundle;
     for (auto printer_it = preset_bundle->printers.begin(); printer_it != preset_bundle->printers.end(); printer_it++) {
         // only use system printer preset
@@ -17421,7 +17443,7 @@ Preset *get_printer_preset(const MachineObject *obj)
         std::string model_id = printer_it->get_current_printer_type(preset_bundle);
 
         std::string printer_type = obj->get_show_printer_type();
-        if (model_id.compare(printer_type) == 0 && printer_nozzle_vals && abs(printer_nozzle_vals->get_at(0) - machine_nozzle_diameter) < 1e-3) {
+        if (model_id.compare(printer_type) == 0 && is_same_nozzle_diameter_vector(printer_nozzle_vals, machine_nozzle_diameters)) {
             printer_preset = &(*printer_it);
         }
     }

--- a/src/slic3r/GUI/SyncAmsInfoDialog.cpp
+++ b/src/slic3r/GUI/SyncAmsInfoDialog.cpp
@@ -1883,9 +1883,7 @@ bool SyncAmsInfoDialog::is_blocking_printing(MachineObject *obj_)
 bool SyncAmsInfoDialog::is_same_nozzle_diameters(NozzleType &tag_nozzle_type, float &nozzle_diameter)
 {
     bool is_same_nozzle_diameters = true;
-
-    float       preset_nozzle_diameters;
-    std::string preset_nozzle_type;
+    float       preset_nozzle_diameters = 0.f;
 
     DeviceManager *dev = Slic3r::GUI::wxGetApp().getDeviceManager();
     if (!dev) return true;
@@ -1896,32 +1894,34 @@ bool SyncAmsInfoDialog::is_same_nozzle_diameters(NozzleType &tag_nozzle_type, fl
     try {
         PresetBundle *preset_bundle        = wxGetApp().preset_bundle;
         auto          opt_nozzle_diameters = preset_bundle->printers.get_edited_preset().config.option<ConfigOptionFloatsNullable>("nozzle_diameter");
+        auto         *plate                = wxGetApp().plater()->get_partplate_list().get_curr_plate();
+        if (plate == nullptr)
+            return true;
 
-        const ConfigOptionEnumsGenericNullable *nozzle_type = preset_bundle->printers.get_edited_preset().config.option<ConfigOptionEnumsGenericNullable>("nozzle_type");
-        std::vector<std::string>                preset_nozzle_types(nozzle_type->size());
-        for (size_t idx = 0; idx < nozzle_type->size(); ++idx) preset_nozzle_types[idx] = NozzleTypeEumnToStr[NozzleType(nozzle_type->values[idx])];
+        auto used_filaments = plate->get_used_filaments(); // 1 based
 
-        std::vector<std::string> machine_nozzle_types(obj_->GetExtderSystem()->GetTotalExtderCount());
-        for (size_t idx = 0; idx < obj_->GetExtderSystem()->GetTotalExtderCount(); ++idx) machine_nozzle_types[idx] = obj_->GetExtderSystem()->GetNozzleType(idx);
-
-        auto used_filaments = wxGetApp().plater()->get_partplate_list().get_curr_plate()->get_used_filaments();                                  // 1 based
-        auto filament_maps  = wxGetApp().plater()->get_partplate_list().get_curr_plate()->get_real_filament_maps(preset_bundle->project_config); // 1 based
-
-        std::vector<int> used_extruders; // 0 based
+        std::vector<int> used_extruders; // physical extruder index, 0 based
         for (auto f : used_filaments) {
-            int filament_extruder = filament_maps[f - 1] - 1;
-            if (std::find(used_extruders.begin(), used_extruders.end(), filament_extruder) == used_extruders.end()) used_extruders.emplace_back(filament_extruder);
+            int physical_extruder = plate->get_physical_extruder_by_filament_id(preset_bundle->project_config, f);
+            if (physical_extruder < 0)
+                continue;
+            if (std::find(used_extruders.begin(), used_extruders.end(), physical_extruder) == used_extruders.end())
+                used_extruders.emplace_back(physical_extruder);
         }
         std::sort(used_extruders.begin(), used_extruders.end());
 
-        // TODO [tao wang] : add idx mapping
-        tag_nozzle_type = obj_->GetExtderSystem()->GetNozzleType(0);
+        if (used_extruders.empty())
+            used_extruders.emplace_back(0);
+        tag_nozzle_type = obj_->GetExtderSystem()->GetNozzleType(used_extruders.front());
 
         if (opt_nozzle_diameters != nullptr) {
-            for (auto i = 0; i < used_extruders.size(); i++) {
+            for (size_t i = 0; i < used_extruders.size(); i++) {
                 auto extruder           = used_extruders[i];
                 preset_nozzle_diameters = float(opt_nozzle_diameters->get_at(extruder));
-                if (preset_nozzle_diameters != obj_->GetExtderSystem()->GetNozzleDiameter(0)) { is_same_nozzle_diameters = false; }
+                if (!is_approx(preset_nozzle_diameters, obj_->GetExtderSystem()->GetNozzleDiameter(extruder))) {
+                    is_same_nozzle_diameters = false;
+                    break;
+                }
             }
         }
 
@@ -1942,15 +1942,22 @@ bool SyncAmsInfoDialog::is_same_nozzle_type(std::string &filament_type, NozzleTy
     MachineObject *obj_ = dev->get_selected_machine();
     if (obj_ == nullptr) return true;
 
-    NozzleType nozzle_type        = obj_->GetExtderSystem()->GetNozzleType(0);
-    auto       printer_nozzle_hrc = Print::get_hrc_by_nozzle_type(nozzle_type);
-
-    auto                   preset_bundle = wxGetApp().preset_bundle;
-    MaterialHash::iterator iter          = m_materialList.begin();
+    auto           *preset_bundle = wxGetApp().preset_bundle;
+    auto           *plate         = wxGetApp().plater()->get_partplate_list().get_curr_plate();
+    if (plate == nullptr)
+        return true;
+    MaterialHash::iterator iter   = m_materialList.begin();
     while (iter != m_materialList.end()) {
-        Material *    item                = iter->second;
-        auto               m              = item->item;
-        auto          filament_nozzle_hrc = preset_bundle->get_required_hrc_by_filament_id(m->m_filament_id);
+        Material *item = iter->second;
+        auto      m    = item->item;
+
+        int physical_extruder = plate->get_physical_extruder_by_filament_id(preset_bundle->project_config, m->m_filament_id);
+        if (physical_extruder < 0)
+            physical_extruder = 0;
+
+        NozzleType nozzle_type        = obj_->GetExtderSystem()->GetNozzleType(physical_extruder);
+        auto       printer_nozzle_hrc = Print::get_hrc_by_nozzle_type(nozzle_type);
+        auto       filament_nozzle_hrc = preset_bundle->get_required_hrc_by_filament_id(m->m_filament_id);
 
         if (abs(filament_nozzle_hrc) > abs(printer_nozzle_hrc)) {
             filament_type = m->m_material_name.ToStdString();
@@ -1958,11 +1965,10 @@ bool SyncAmsInfoDialog::is_same_nozzle_type(std::string &filament_type, NozzleTy
             is_same_nozzle_type = false;
             tag_nozzle_type     = NozzleType::ntHardenedSteel;
             return is_same_nozzle_type;
-        } else {
-            tag_nozzle_type = obj_->GetExtderSystem()->GetNozzleType(0);
         }
 
-        iter++;
+        tag_nozzle_type = nozzle_type;
+        ++iter;
     }
 
     return is_same_nozzle_type;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add mixed-nozzle layer-grid classification helpers in `Slicing.hpp/.cpp`:
  - `LayerGridMode` (`shared-grid`, `separate-object-independent-grid`, `same-object-compatible-cadence`, `unsupported`)
  - `nozzle_vector_has_compatible_cadence(...)`
  - `classify_layer_grid_mode(...)`
- update `SlicingParameters::create_from_config()` extruder/nozzle index handling to use the documented 1-based nozzle helper contract when deriving min/max layer-height bounds from object extruders.
- update `Print::validate()` to:
  - classify print grid mode before wipe-tower gating
  - reject only unsupported mixed-nozzle/schedule combinations with targeted messages
  - remove the blanket prime-tower rejection for mixed nozzle diameters
  - keep filament-diameter mismatch checks for prime tower
  - keep strict shared-grid checks when the print is in shared-grid mode, while allowing non-shared object grids to pass this stage unless other unsupported conditions apply
- clean up user-facing nozzle index-0 assumptions:
  - `Plater.cpp` preset/device matching now compares full per-extruder nozzle vectors instead of `GetNozzleDiameter(0)` / preset index `0`
  - `SyncAmsInfoDialog.cpp` nozzle diameter/type checks now use per-used-filament mapped physical extruders
  - `PartPlate.cpp` nozzle/filament compatibility checks now evaluate used extruders instead of a single nozzle index `0`
- fix tool-ordering single-extruder stats fallback to avoid synthesizing nozzle diameter directly from index `0`; now derives a representative diameter from used extruders and formats it explicitly.

## Validation
- `cmake -S . -B build -G Ninja` *(fails in this environment: Ninja unavailable)*
- `cmake -S . -B build_make -G "Unix Makefiles"` *(configure fails due missing linker runtime: `/usr/bin/ld: cannot find -lstdc++`)*

## Notes
- This is an intentionally narrow first-pass for mixed-nozzle support:
  - explicit compatibility classification + fail-closed unsupported cases
  - removal of blanket nozzle-equality prime-tower rejection
  - per-extruder nozzle-vector matching in user-facing sync/matching flows
- Full arbitrary same-object independent Z scheduling and per-extruder tower architecture remain out of scope for this patch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a023905b-9be3-461e-b0dd-c2c495aaad82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a023905b-9be3-461e-b0dd-c2c495aaad82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

